### PR TITLE
Trace markers and request ids

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7580,6 +7580,14 @@
         "promise": "^8.1.0"
       }
     },
+    "express-request-id": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/express-request-id/-/express-request-id-1.4.1.tgz",
+      "integrity": "sha512-qpxK6XhDYtdx9FvxwCHkUeZVWtkGbWR87hBAzGECfwYF/QQCPXEwwB2/9NGkOR1tT7/aLs9mma3CT0vjSzuZVw==",
+      "requires": {
+        "uuid": "^3.3.2"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       "dotenv": "^8.2.0",
       "express": "^4.17.1",
       "express-handlebars": "^4.0.3",
+      "express-request-id": "^1.4.1",
       "graphql-tools": "^5.0.0",
       "helmet": "^3.22.0",
       "i18next": "^19.4.3",

--- a/src/server/helpers/resolveBundle.js
+++ b/src/server/helpers/resolveBundle.js
@@ -1,33 +1,32 @@
 import path from 'path';
 import fs from 'fs';
-import createLogger from '../utils/logger';
 
-const log = createLogger('resolveBundle');
+export default function resolveBundle(logger) {
+   return function(bundleName) {
+      const manifestPath = path.resolve(
+         process.cwd(),
+         'build',
+         'public',
+         'manifest.json'
+      );
 
-export default function resolveBundle(bundleName) {
-   const manifestPath = path.resolve(
-      process.cwd(),
-      'build',
-      'public',
-      'manifest.json'
-   );
+      let manifest;
+      try {
+         if (fs.existsSync(manifestPath)) {
+            // eslint-disable-next-line import/no-dynamic-require
+            manifest = require(manifestPath);
+            return `/public/${manifest[bundleName]}`;
+         }
 
-   let manifest;
-   try {
-      if (fs.existsSync(manifestPath)) {
-         // eslint-disable-next-line import/no-dynamic-require
-         manifest = require(manifestPath);
-         return `/public/${manifest[bundleName]}`;
+         return `/public/${bundleName}`;
+      } catch (error) {
+         logger.error({
+            logId: 'e3cbb634-0db8-4f03-a708-29f2f75a5137',
+            message: 'Failed to find manifest file for bundle resolution.',
+            error
+         });
+
+         throw error;
       }
-
-      return `/public/${bundleName}`;
-   } catch (error) {
-      log.error({
-         logId: 'e3cbb634-0db8-4f03-a708-29f2f75a5137',
-         message: 'Failed to find manifest file for bundle resolution.',
-         error
-      });
-
-      throw error;
-   }
+   };
 }

--- a/src/server/helpers/retrieveLanguageFile.js
+++ b/src/server/helpers/retrieveLanguageFile.js
@@ -1,16 +1,12 @@
 import path from 'path';
 import fs from 'fs';
-import serialize from 'serialize-javascript';
-import createLogger from '../utils/logger';
-
-const log = createLogger('retrieveDefaultLanguage');
 
 /**
  *
  * @param {string} locale
  * @returns {string|{}}
  */
-export default function retrieveLanguageFile(locale) {
+export default function retrieveLanguageFile(request, locale) {
    const enPath = path.resolve(process.cwd(), 'translations', `${locale}.json`);
 
    try {
@@ -18,13 +14,13 @@ export default function retrieveLanguageFile(locale) {
          return JSON.parse(fs.readFileSync(enPath, { flag: 'r' }));
       }
 
-      log.error({
+      request.log.error({
          logId: '014c9d67-f036-4d4a-8502-669b0da37c7e',
          message: `Default language file does not exist at "${enPath}"`,
       });
       return {};
    } catch (error) {
-      log.error({
+      request.log.error({
          logId: 'a8c84309-05d3-4408-b986-944d2db6578b',
          message: `Failed to read default language file from "${enPath}"`,
          error

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -14,7 +14,7 @@ const app = express();
 const log = createLogger('Server');
 
 const cspSelf = ["'self'"];
-attachMiddleware(app, {
+attachMiddleware(app, log,{
    graphQLRoute: '/graphql',
    ignoredMutations: [],
    contentSecurityPolicy: {

--- a/src/server/middleware/logger.js
+++ b/src/server/middleware/logger.js
@@ -1,0 +1,14 @@
+import createLogger from '../utils/logger';
+
+/**
+ * Custom middleware that adds a log function on the request.  The argument
+ * to createLogger is the bunyan widget_type.  This is used a trace marker
+ * to correlate log messages to the request that generated them.
+ * @param req
+ * @param res
+ * @param next
+ */
+export default function requestLogger(req, res, next) {
+   req.log = createLogger(req.id);
+   next();
+}

--- a/src/server/middleware/tracer.js
+++ b/src/server/middleware/tracer.js
@@ -1,0 +1,18 @@
+/**
+ * @returns {string}
+ */
+function randomString() {
+   const CHARS = '0123456789abcdefghijklmnopqrstuvwxyz';
+   let ans = '';
+   // eslint-disable-next-line no-plusplus
+   for (let i = 16; i > 0; --i) {
+      ans
+         += CHARS[Math.floor(Math.random() * CHARS.length)];
+   }
+   return ans;
+}
+
+export default function createTracer(req, res, next) {
+   req.tracer = randomString();
+   next();
+}

--- a/src/server/middleware/viewEngine.js
+++ b/src/server/middleware/viewEngine.js
@@ -6,11 +6,11 @@ import resolveBundle from '../helpers/resolveBundle';
  * @param {Object} app Express application object
  * @param {string} viewsDir The path to the custom views directory
  */
-export default function registerViewEngine(app, viewsDir) {
+export default function registerViewEngine(app, logger, viewsDir) {
    const extname = '.hbs';
    app.engine(
       extname,
-      handlebarsEngine({ extname, helpers: { resolveBundle } })
+      handlebarsEngine({ extname, helpers: { resolveBundle: resolveBundle(logger) } })
    );
    app.set('view engine', extname);
    app.set('views', viewsDir);

--- a/src/server/routes/main.js
+++ b/src/server/routes/main.js
@@ -6,9 +6,10 @@ import Root from '../../universal/components/Root';
 import i18nInit from '../utils/i18n';
 
 export default async function main(req, res) {
-   await i18nInit();
    const locale = 'en';
-   const rawLanguage = retrieveLanguageFile(locale);
+   const rawLanguage = retrieveLanguageFile(req, locale);
+   await i18nInit(rawLanguage);
+
    const language = serialize(rawLanguage, { isJSON: true });
 
    const body = renderToString(<Root/>);

--- a/src/server/utils/i18n.js
+++ b/src/server/utils/i18n.js
@@ -1,10 +1,10 @@
 import i18n from 'i18next';
 import retrieveLanguageFile from '../helpers/retrieveLanguageFile';
 
-export default async () => {
+export default async (translation) => {
    const resources = {
       en: {
-         translation: await retrieveLanguageFile('en', false)
+         translation: translation
       }
    };
 


### PR DESCRIPTION
Request ids are now placed on every incoming request.  An `X-Request-Id` header is added as well.  Logging was updated to ensure the output of the request id on every log message.  The request id can be found conveniently at `req.id` for any future use.

It is expected that the `X-Request-Id` header will be propagated to any upstream services as well in order to correlate request flows through the platform.